### PR TITLE
getting libltdl.so.7 missing during docker pull

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -117,7 +117,7 @@ RUN groupadd docker -g ${HOST_DOCKER_GROUP_ID} && \
     usermod -a -G docker jenkins
 
 
-RUN apt-get update && apt-get install -y tree nano curl sudo
+RUN apt-get update && apt-get install -y libltdl7 tree nano curl sudo
 RUN curl https://get.docker.com/builds/Linux/x86_64/docker-latest.tgz | tar xvz -C /tmp/ && mv /tmp/docker/docker /usr/bin/docker
 RUN curl -L "https://github.com/docker/compose/releases/download/1.23.1/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
 RUN chmod 755 /usr/local/bin/docker-compose


### PR DESCRIPTION
[Pipeline] sh
+ docker inspect -f . maven:3-alpine
docker: error while loading shared libraries: libltdl.so.7: cannot open shared object file: No such file or directory
[Pipeline] sh
+ docker pull maven:3-alpine
docker: error while loading shared libraries: libltdl.so.7: cannot open shared object file: No such file or directory
[Pipeline] }